### PR TITLE
fix: Transpiling to ES6 with browserslist

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,11 @@
     "production": [
       ">0.2%",
       "not dead",
-      "not op_mini all"
+      "not op_mini all",
+      "not safari < 10",
+      "not chrome < 51",
+      "not android < 5",
+      "not ie < 12"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
When I merge this PR https://github.com/yutakusuno/world-weather-map/pull/1 and deployed, an error occurred like the bellow,

> An error occurred while parsing the WebWorker bundle. This is most likely due to improper transpilation by Babel; please see https://docs.mapbox.com/mapbox-gl-js/guides/install/#transpiling

This is most likely due to improper transpilation by Babel. I fixed `package.json` as the description of the link mentioned.